### PR TITLE
Adding option to create image with specified versions of dependencies

### DIFF
--- a/.semaphore/push.yml
+++ b/.semaphore/push.yml
@@ -8,7 +8,7 @@ blocks:
   - name: Push
     task:
       jobs:
-        - name: make build & push
+        - name: Elixir v1.8.2, protoc v0.5.4
           commands:
             - checkout
             - docker login

--- a/.semaphore/push_parametrised_versions.yml
+++ b/.semaphore/push_parametrised_versions.yml
@@ -1,0 +1,19 @@
+version: v1.0
+name: Push Parametrised versions to Dockerhub
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Push
+    task:
+      jobs:
+        - name: build and push parametrised versions
+          commands:
+            - checkout
+            - docker login
+            - make image.build.versions PROTOBUF_VERSION=$PROTOBUF_VERSION ELIXIR_VERSION=$ELIXIR_VERSION PROTOC_VERSION=$PROTOC_VERSION
+            - make push.tagged.versions DOCKER_IMAGE_VERSIONS_TAG=$ELIXIR_VERSION-$PROTOC_VERSION-$PROTOBUF_VERSION
+      secrets:
+        - name: dockerhub-robot
+

--- a/.semaphore/push_parametrised_versions.yml
+++ b/.semaphore/push_parametrised_versions.yml
@@ -1,5 +1,5 @@
 version: v1.0
-name: Push Parametrised versions to Dockerhub
+name: Push Image to DockerHub - elixir ${{parameters.ELIXIR_VERSION}}, protoc ${{parameters.PROTOC_VERSION}}, protobuf  ${{parameters.PROTOBUF_VERSION}}
 agent:
   machine:
     type: e1-standard-2

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -20,3 +20,16 @@ promotions:
     pipeline_file: push.yml
     auto_promote:
       when: branch = 'master' AND result = 'passed'
+  - name: Push Parametrised versions to Dockerhub
+    pipeline_file: push_parametrised_versions.yml
+    parameters:
+      env_vars:
+        - required: true
+          default_value: 1.11.4
+          name: ELIXIR_VERSION
+        - required: true
+          default_value: 3.17.3
+          name: PROTOC_VERSION
+        - required: false
+          description: Latest version will be installed when not set
+          name: PROTOBUF_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,23 @@
-FROM elixir:1.8.2-alpine
+ARG ELIXIR_VERSION
+
+FROM elixir:${ELIXIR_VERSION}-alpine
 MAINTAINER Rendered Text <devs@renderedtext.com>
 
 WORKDIR /tmp
+
+ARG PROTOC_VERSION
+ARG PROTOBUF_VERSION
 
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
 RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.33-r0/glibc-2.33-r0.apk
 RUN apk add glibc-2.33-r0.apk
 
-RUN wget -O /tmp/protoc https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_64.zip
+RUN wget -O /tmp/protoc https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
 RUN unzip protoc
 RUN mv bin/protoc /usr/local/bin/protoc
 
 RUN mix local.hex --force
-RUN mix escript.install hex protobuf 0.5.4 --force
+RUN mix escript.install hex protobuf ${PROTOBUF_VERSION} --force
 
 RUN mkdir -p /home/protoc
 VOLUME /home/protoc/source

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,30 @@
 .PHONY: build push
 
+REPO=renderedtext/protoc
+IMAGE_LATEST=$(REPO):latest
 DOCKER_IMAGE_TAG=$(shell git rev-parse --short HEAD)
 
+ELIXIR_VERSION=1.11.4
+PROTOC_VERSION=3.17.3
+PROTOBUF_VERSION=
+
+DOCKER_IMAGE_VERSIONS_TAG=$(ELIXIR_VERSION)-$(PROTOC_VERSION)-$(PROTOBUF_VERSION)
+
+image.build.versions:
+		docker build \
+			-t $(REPO) -t $(IMAGE_LATEST) . \
+			--build-arg ELIXIR_VERSION=$(ELIXIR_VERSION) \
+			--build-arg PROTOC_VERSION=$(PROTOC_VERSION) \
+			--build-arg PROTOBUF_VERSION=$(PROTOBUF_VERSION) \
+
 build:
-		docker build -t renderedtext/protoc .
+		$(MAKE) image.build.versions PROTOBUF_VERSION="0.5.4" ELIXIR_VERSION="1.8.2" PROTOC_VERSION=3.3.0
 
 push:
-		docker tag renderedtext/protoc:latest renderedtext/protoc:$(DOCKER_IMAGE_TAG)
-		docker push renderedtext/protoc:$(DOCKER_IMAGE_TAG)
-		docker push renderedtext/protoc:latest
+		docker tag $(IMAGE_LATEST) $(REPO):$(DOCKER_IMAGE_TAG)
+		docker push $(REPO):$(DOCKER_IMAGE_TAG)
+		docker push $(IMAGE_LATEST)
+
+push.tagged.versions:
+		docker tag $(IMAGE_LATEST) $(REPO):$(DOCKER_IMAGE_VERSIONS_TAG)
+		docker push $(REPO):$(DOCKER_IMAGE_VERSIONS_TAG)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,54 @@
 # Dockerized Protoc
 
-Run protoc for `/tmp/internal_api/user.proto` file and put out into `/Users/radwo/workspace/semaphore/front/protos/internal_api`:
+This repository holds receipts for production of Dockerized `protoc` plugin for Elixir.
+We use these Docker images in the development process accross our Elixir projects
+in order to make sure that every team member uses the same `protoc` version.
+
+## Usage
+
+Docker run should be executed with the following options set:
+- assign local directories to the following Docker container volumes `/home/protoc/code` and `/home/protoc/source`
+  - `/home/protoc/code` - working directory (`$PWD` in the following example)
+  - `/home/protoc/source` - directory that contains already generated protos (`$TMP_PROTO_DIR`)
+- specify the protos output path within your local environment (`$PROTO_OUTPUT_DIR`)
+- specify Docker container path of the target `proto` file (ie. file that needs to be compiled with `protoc` and is present in `$TMP_PROTO_DIR` locally; eg. `/home/protoc/source/user.proto`)
+- specify Docker protoc image tag (`$PROTOC_IMG_VSN`); when not specified `latest` will be used
 
 ``` bash
-docker run --rm -v /Users/radwo/workspace/semaphore/front:/home/protoc/code -v /tmp/internal_api:/home/protoc/source \
-  renderedtext/protoc protoc -I /home/protoc/source -I /home/protoc/source/include \
-  --elixir_out=plugins=grpc:/home/protoc/code/protos/internal_api \
+docker run --rm -v $PWD:/home/protoc/code -v $TMP_PROTO_DIR:/home/protoc/source \
+  renderedtext/protoc:$PROTOC_IMG_VSN protoc -I /home/protoc/source -I /home/protoc/source/include \
+  --elixir_out=plugins=grpc:$PROTO_OUTPUT_DIR \
   --plugin=/root/.mix/escripts/protoc-gen-elixir /home/protoc/source/user.proto
 ```
+
+## Deployment
+
+New Docker image deployment is managed with the following promotions
+within [`docker-protoc`] Semaphore project:
+- parametrized promotion
+- legacy promotion
+
+Resulting Docker images are tagged (as described below) and pushed to Dockerhub repository ([`renderedtext/protoc`]).
+
+### Parametrized promotion
+
+Available parameters:
+
+- Elixir version (required, default `v1.11.4`)
+- `protoc` version (required, default `3.17.3`)
+- Protobuf version (optional)
+
+This promotion constructs a tag in the following form:
+
+`<elixir_version>-<protoc_version>-<protobuf_version>`
+
+### Legacy promotion
+
+This promotion relies on `make build` and `make push` target sequences.
+Produced image is pushed to repository with `latest` and `git commit sha` tags.
+It is based on `Elixir v1.8.2`, `Protobuf v0.5.4` and `protoc v3.3.0`.
+This image is used by some of projects in the production (eg. UI project [`front`]).
+
+[`docker-protoc`]: https://semaphore.semaphoreci.com/projects/docker-protoc
+[`renderedtext/protoc`]: https://hub.docker.com/repository/docker/renderedtext/protoc
+[`front`]: https://semaphore.semaphoreci.com/projects/front


### PR DESCRIPTION
This PR:
- adds option for us to create a `protoc` Docker image with arbitrary combination of Elixir, protobuf and protoc when needed
- employs parametrised promotions to achieve this
- saves image tagged with `latest`

There are more info in the README.

If you find anything confusing or have any feedback/suggestion, pls let me know. 