### PR TITLE
Has/fix dockerfile glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG PROTOBUF_VERSION
 
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
 RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.33-r0/glibc-2.33-r0.apk
-RUN apk add glibc-2.33-r0.apk
+RUN apk add --force-overwrite glibc-2.33-r0.apk
 
 RUN wget -O /tmp/protoc https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
 RUN unzip protoc

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,11 @@ PROTOBUF_VERSION=
 DOCKER_IMAGE_VERSIONS_TAG=$(ELIXIR_VERSION)-$(PROTOC_VERSION)-$(PROTOBUF_VERSION)
 
 image.build.versions:
-		docker build \
+		docker buildx ls
+		docker buildx create --name mybuilder
+		docker buildx use mybuilder
+		docker buildx build \
+			--platform linux/amd64,linux/arm64 \
 			-t $(REPO) -t $(IMAGE_LATEST) . \
 			--build-arg ELIXIR_VERSION=$(ELIXIR_VERSION) \
 			--build-arg PROTOC_VERSION=$(PROTOC_VERSION) \


### PR DESCRIPTION
when building this image on mac M1 with elixir version 1.13.4 there is an issue with `Dockerfile` in installing glibc.
The thread about this issue can be found [here](https://github.com/sgerrand/alpine-pkg-glibc/issues/185).