### PR TITLE
fixes issue with glibc overwrite nsswitch.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG PROTOBUF_VERSION
 
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
 RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.33-r0/glibc-2.33-r0.apk
-RUN apk add glibc-2.33-r0.apk
+RUN apk add --force-overwrite glibc-2.33-r0.apk
 
 RUN wget -O /tmp/protoc https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
 RUN unzip protoc


### PR DESCRIPTION
When building this image on mac M1 with elixir version 1.13.4 there is an issue with Dockerfile in installing glibc.
The thread about this issue can be found [here](https://github.com/sgerrand/alpine-pkg-glibc/issues/185).